### PR TITLE
🐛 fix: 사용자 구매 요청 상품 중복 주문되는 버그 해결 - 사용자 장바구니에 있는 상품만 결제되도록 구현

### DIFF
--- a/src/main/java/com/example/commercepjt/common/enums/DeliveryStatus.java
+++ b/src/main/java/com/example/commercepjt/common/enums/DeliveryStatus.java
@@ -2,7 +2,7 @@ package com.example.commercepjt.common.enums;
 
 public enum DeliveryStatus {
 
-    CREATED("주문 생성"), READY("준비 중"), IN_TRANSIT("배송 중"), DONE("배송 완료"), CANCEL("주문 취소");
+    IN_BAG("장바구니"), CREATED("주문 생성"), READY("준비 중"), IN_TRANSIT("배송 중"), DONE("배송 완료"), CANCEL("주문 취소");
 
     private String value;
 

--- a/src/main/java/com/example/commercepjt/domain/OrderItem.java
+++ b/src/main/java/com/example/commercepjt/domain/OrderItem.java
@@ -54,16 +54,25 @@ public class OrderItem extends BaseEntity {
         this.order = order;
         this.itemQuantity = itemQuantity;
         this.purchasedItemPrice = purchasedItemPrice;
-        this.deliveryStatus = DeliveryStatus.CREATED;
+        this.deliveryStatus = DeliveryStatus.IN_BAG;
     }
 
     public void setDeliveryStatus(DeliveryStatus deliveryStatus) {
         switch (deliveryStatus) {
+            case CREATED -> this.setDeliveryStatusToCreated();
             case READY -> this.setDeliveryStatusToReady();
             case IN_TRANSIT -> this.setDeliveryStatusToInTransit();
             case DONE -> this.setDeliveryStatusToDone();
             case CANCEL -> this.setDeliveryStatusToCancel();
         }
+    }
+
+    private void setDeliveryStatusToCreated() {
+        if (this.deliveryStatus == DeliveryStatus.IN_BAG) {
+            this.deliveryStatus = DeliveryStatus.CREATED;
+            return;
+        }
+        throw new RuntimeException("Delivery status can be changed from in_bag");
     }
 
     private void setDeliveryStatusToReady() {

--- a/src/main/java/com/example/commercepjt/repository/OrderItemRepository.java
+++ b/src/main/java/com/example/commercepjt/repository/OrderItemRepository.java
@@ -1,5 +1,6 @@
 package com.example.commercepjt.repository;
 
+import com.example.commercepjt.common.enums.DeliveryStatus;
 import com.example.commercepjt.domain.OrderItem;
 import java.util.List;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -8,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
 
     @EntityGraph(attributePaths = {"item"})
-    List<OrderItem> findAllByUserBuyerId(Long userBuyerId);
+    List<OrderItem> findAllByUserBuyerIdAndDeliveryStatus(Long userBuyerId, DeliveryStatus deliveryStatus);
 
     OrderItem findByIdAndUserBuyerId(Long id, Long userBuyerId);
 }

--- a/src/main/java/com/example/commercepjt/service/OrderItemService.java
+++ b/src/main/java/com/example/commercepjt/service/OrderItemService.java
@@ -24,8 +24,8 @@ public class OrderItemService {
         return orderItemRepository.findById(id).orElseThrow(EntityNotFoundException::new);
     }
 
-    public List<OrderItem> findAllItemsByBuyerId(long buyerId) {
-        return orderItemRepository.findAllByUserBuyerId(buyerId);
+    public List<OrderItem> findAllItemsByBuyerIdAndStatusIsInBag(long buyerId) {
+        return orderItemRepository.findAllByUserBuyerIdAndDeliveryStatus(buyerId, DeliveryStatus.IN_BAG);
     }
 
     public OrderItem updateOrderItemDeliveryStatus(long orderItemId, long buyerId,

--- a/src/main/java/com/example/commercepjt/service/facade/BuyerFacadeService.java
+++ b/src/main/java/com/example/commercepjt/service/facade/BuyerFacadeService.java
@@ -1,5 +1,6 @@
 package com.example.commercepjt.service.facade;
 
+import com.example.commercepjt.common.enums.DeliveryStatus;
 import com.example.commercepjt.common.enums.PaymentStatus;
 import com.example.commercepjt.domain.Item;
 import com.example.commercepjt.domain.Order;
@@ -55,7 +56,7 @@ public class BuyerFacadeService {
      * @return
      */
     public List<OrderItemCreatedDto> getOrderItemListInBag(long buyerId) {
-        List<OrderItem> foundOrderItems = orderItemService.findAllItemsByBuyerId(buyerId);
+        List<OrderItem> foundOrderItems = orderItemService.findAllItemsByBuyerIdAndStatusIsInBag(buyerId);
 
         return foundOrderItems.stream().map(OrderItemCreatedDto::new).collect(
             Collectors.toList());
@@ -71,13 +72,14 @@ public class BuyerFacadeService {
     @Transactional
     public OrderCreatedDto createOrder(long buyerId) throws Exception {
         UserBuyer buyer = userBuyerService.getUserBuyerById(buyerId);
-        List<OrderItem> orderItemList = orderItemService.findAllItemsByBuyerId(buyerId);
+        List<OrderItem> orderItemList = orderItemService.findAllItemsByBuyerIdAndStatusIsInBag(buyerId);
 
         for (OrderItem orderItem : orderItemList) {
             Item item = orderItem.getItem();
             orderItem.setPurchasedItemPrice(
                 item.getPrice() * orderItem.getItemQuantity());
             item.minusStockQuantity(orderItem.getItemQuantity());
+            orderItem.setDeliveryStatus(DeliveryStatus.CREATED);
         }
 
         Order order = Order.builder().userBuyer(buyer).orderItemList(orderItemList).paymentStatus(

--- a/src/test/java/com/example/commercepjt/service/facade/SellerFacadeServiceTest.java
+++ b/src/test/java/com/example/commercepjt/service/facade/SellerFacadeServiceTest.java
@@ -11,6 +11,7 @@ import com.example.commercepjt.domain.UserBuyer;
 import com.example.commercepjt.domain.UserSeller;
 import com.example.commercepjt.dto.response.ItemDto;
 import com.example.commercepjt.dto.response.OrderCreatedDto;
+import com.example.commercepjt.dto.response.OrderItemCreatedDto;
 import com.example.commercepjt.repository.CategoryRepository;
 import com.example.commercepjt.repository.ItemMarginRepository;
 import com.example.commercepjt.repository.ItemRepository;
@@ -56,7 +57,7 @@ class SellerFacadeServiceTest {
             ItemMargin.builder().marginRate("1.1").build());
         item = itemRepository.save(
             Item.builder().name("item").category(category).userSeller(userSeller).price(1000)
-                .itemMargin(itemMargin).stockQuantity(100).build());
+                .itemMargin(itemMargin).stockQuantity(1000).build());
         userBuyer = userBuyerRepository.save(
             UserBuyer.builder().loginId("buyer-id").loginPassword("buyer-pwd").point(1000).build());
     }
@@ -75,7 +76,7 @@ class SellerFacadeServiceTest {
     @Test
     public void whenChangeDeliveryStatusToReady_thenReturnOrderStatus() throws Exception {
         //given
-        int originStockQuantity = item.getStockQuantity();
+        int originStockQuantity = itemRepository.findById(1L).get().getStockQuantity();
         OrderCreatedDto orderCreatedDto = createOrder();
 
         //when


### PR DESCRIPTION
- 🐛 fix: 사용자 구매 요청 상품 중복 주문되는 버그 해결 - 사용자 장바구니에 있는 상품만 결제되도록 구현

사용자 주문 처리 시, 상품에 대해서 중복 주문되는 버그 해결. 상품 조회 시, 주문 상태에 대한 조건이 누락되어 있었음